### PR TITLE
Fix clear mailables

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,29 @@ Here is an example using handlebars templating engine. Learn more about using Ha
 
 > When this class is provided it will be used in resolving the templates. You must ensure your your mail messages are formatted based on the templating engine you are using as your resolver. 
 
+## Deleting Mailables
+LaraNotice provides a convenient command to clean up mailable classes and their associated database records.
+
+```bash
+# Delete a specific mailable class
+php artisan mailable:delete --class=ExampleMailable
+
+# Delete all mailable classes
+php artisan mailable:delete --all
+
+# Delete with preservation options
+php artisan mailable:delete --class=ExampleMailable --preserve=database  # Only deletes the file
+php artisan mailable:delete --class=ExampleMailable --preserve=files     # Only deletes from database
+```
+
+### Command Options
+- `--all`: Delete all mailable classes and their database records
+- `--class=`: Specify a single mailable class to delete (e.g., ExampleMailable)
+- `--preserve=`: Optional. Specify what to keep:
+  - `database`: Preserves database records but deletes files
+  - `files`: Preserves files but deletes database records
+
+The command will ask for confirmation before performing any deletions to prevent accidental data loss.
 
 ## Testing
 ```bash

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,71 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "5c3bfcfdbe32d9ef99ba21f6edbaa8c1",
+    "packages": [
+        {
+            "name": "mustache/mustache",
+            "version": "v2.14.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bobthecow/mustache.php.git",
+                "reference": "e62b7c3849d22ec55f3ec425507bf7968193a6cb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bobthecow/mustache.php/zipball/e62b7c3849d22ec55f3ec425507bf7968193a6cb",
+                "reference": "e62b7c3849d22ec55f3ec425507bf7968193a6cb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.4"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~1.11",
+                "phpunit/phpunit": "~3.7|~4.0|~5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Mustache": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Justin Hileman",
+                    "email": "justin@justinhileman.info",
+                    "homepage": "http://justinhileman.com"
+                }
+            ],
+            "description": "A Mustache implementation in PHP.",
+            "homepage": "https://github.com/bobthecow/mustache.php",
+            "keywords": [
+                "mustache",
+                "templating"
+            ],
+            "support": {
+                "issues": "https://github.com/bobthecow/mustache.php/issues",
+                "source": "https://github.com/bobthecow/mustache.php/tree/v2.14.2"
+            },
+            "time": "2022-08-23T13:07:01+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=7.0"
+    },
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}

--- a/src/Commands/DeleteMailable.php
+++ b/src/Commands/DeleteMailable.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Utyemma\LaraNotice\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Utyemma\LaraNotice\Models\Mailable;
+
+class DeleteMailable extends Command
+{
+    protected $signature = 'mailable:delete
+                        {--all : Delete all mailable classes}
+                        {--class= : Specify a single mailable class to delete}
+                        {--preserve= : Keep either database records or files (database|files)}';
+
+    protected $description = 'Delete mailable classes from filesystem and/or database';
+
+    private $baseMailablePath;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->baseMailablePath = app_path('Mailables');
+    }
+
+    public function handle()
+    {
+        if (!$this->option('all') && !$this->option('class')) {
+            $this->error('Please specify either --all or --class option');
+            return 1;
+        }
+
+        if ($this->option('all')) {
+            return $this->deleteAllMailables();
+        }
+
+        return $this->deleteSingleMailable();
+    }
+
+    private function deleteAllMailables()
+    {
+        if (!$this->confirmDeletion('all mailables')) {
+            return 1;
+        }
+
+        $preserveOption = $this->option('preserve');
+
+        if (!$preserveOption || $preserveOption === 'files') {
+            $deletedCount = Mailable::count();
+            Mailable::truncate();
+            $this->info("Deleted {$deletedCount} database records");
+        }
+
+        if (!$preserveOption || $preserveOption === 'database') {
+            if (File::exists($this->baseMailablePath)) {
+                File::deleteDirectory($this->baseMailablePath);
+                $this->info('Deleted all mailable files');
+            }
+        }
+
+        $this->info('All mailables have been deleted successfully');
+        return 0;
+    }
+
+    private function deleteSingleMailable()
+    {
+        $className = $this->option('class');
+        $fullClassName = "App\\Mailables\\{$className}";
+
+        if (!$this->confirmDeletion($className)) {
+            return 1;
+        }
+
+        $preserveOption = $this->option('preserve');
+
+        if (!$preserveOption || $preserveOption === 'files') {
+            $mailable = Mailable::whereMailable($fullClassName)->first();
+            if ($mailable) {
+                $mailable->delete();
+                $this->info("Deleted database record for {$className}");
+            }
+        }
+
+        if (!$preserveOption || $preserveOption === 'database') {
+            $filePath = "{$this->baseMailablePath}/{$className}.php";
+            if (File::exists($filePath)) {
+                File::delete($filePath);
+                $this->info("Deleted file for {$className}");
+            }
+        }
+
+        $this->info("{$className} has been deleted successfully");
+        return 0;
+    }
+
+    private function confirmDeletion($target)
+    {
+        return $this->confirm(
+            "Are you sure you want to delete {$target}? This action cannot be undone.",
+            false
+        );
+    }
+}

--- a/src/LaraNoticeServiceProvider.php
+++ b/src/LaraNoticeServiceProvider.php
@@ -4,20 +4,23 @@ namespace Utyemma\LaraNotice;
 
 use Illuminate\Support\ServiceProvider;
 use Utyemma\LaraNotice\Commands\CreateMailable;
+use Utyemma\LaraNotice\Commands\DeleteMailable;
 
-class LaraNoticeServiceProvider extends ServiceProvider {
+class LaraNoticeServiceProvider extends ServiceProvider
+{
 
-    function boot(){
+    function boot()
+    {
         $this->registerCommands();
 
-        $this->loadMigrationsFrom(__DIR__.'/../database/migrations/2024_01_18_133341_create_mailables_table.php');
+        $this->loadMigrationsFrom(__DIR__ . '/../database/migrations/2024_01_18_133341_create_mailables_table.php');
 
         $this->publishes([
-            __DIR__.'/../config/laranotice.php' => config_path('laranotice.php'),
+            __DIR__ . '/../config/laranotice.php' => config_path('laranotice.php'),
         ]);
 
         $this->publishes([
-            __DIR__.'/../database/migrations/' => database_path('migrations'),
+            __DIR__ . '/../database/migrations/' => database_path('migrations'),
         ], 'laranotice-migrations');
 
         // $this->app->bind('notifire', function($app) {
@@ -25,18 +28,21 @@ class LaraNoticeServiceProvider extends ServiceProvider {
         // });
     }
 
-    function register() {
+    function register()
+    {
         $this->mergeConfigFrom(
-            __DIR__.'/../config/laranotice.php', 'laranotice'
+            __DIR__ . '/../config/laranotice.php',
+            'laranotice'
         );
     }
 
-    function registerCommands(){
-        if($this->app->runningInConsole()){
+    function registerCommands()
+    {
+        if ($this->app->runningInConsole()) {
             $this->commands([
-                CreateMailable::class
+                CreateMailable::class,
+                DeleteMailable::class
             ]);
         }
     }
-
 }


### PR DESCRIPTION
   Added documentation for the new mailable:delete command
   
   - Documents the new artisan command for deleting mailables
   - Includes examples of all command options
   - Explains preservation options for files and database records
   - Added safety confirmation information